### PR TITLE
Replace use key with uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
       # ^^ this is the simplest use, runs tests for whatever platform `xcodebuild` picks
 ```
 
@@ -37,7 +37,7 @@ jobs:
           - iOS
           - mac-catalyst
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
         with:
           platform: ${{ matrix.platform }}
 ```
@@ -58,7 +58,7 @@ jobs:
           - ^12
     runs-on: macos-10.15
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
         with:
           xcode: ${{ matrix.xcode }}
           platform: ${{ matrix.platform }}
@@ -81,7 +81,7 @@ jobs:
           - ~5.4
           - ^6
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
         with:
           swift: ${{ matrix.swift }}
           # ^^ mxcl/xcodebuild selects the newest Xcode that provides the requested Swift
@@ -112,7 +112,7 @@ jobs:
           - swift: ~5.5
             os: macos-11 # Xcode 13
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
         with:
           swift: ${{ matrix.swift }}
 ```
@@ -124,7 +124,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
         with:
           action: none
       - run: … # do your own thing
@@ -199,7 +199,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
         with:
           authentication-key-base64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
           authentication-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
@@ -230,7 +230,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
         with:
           code-sign-certificate: ${{ secrets.CERTIFICATE_BASE64 }}
           code-sign-certificate-passphrase: ${{ secrets.CERTIFICATE_PASSPHRASE}}
@@ -265,7 +265,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - use: mxcl/xcodebuild@v1
+      - uses: mxcl/xcodebuild@v1
         with:
           mobile-provisioning-profiles-base64: |
             ${{ secrets.IPHONE_PROVISIONING_PROFILE_BASE64 }}


### PR DESCRIPTION
This pull request the `use` key with `uses`, otherwise the following error will occur:
```
every step must define a uses or run key
```