### PR TITLE
Add documentation for workspace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ jobs:
       - run: … # do your own thing
 ```
 
+## Specifying `workspace`
+
+You can specify `workspace`.
+
+If you are using CocoaPods you will likely need to specify the workspace, it is NOT automatically
+deciphered for you.
+
 ## Specifying `scheme`
 
 You can specify `scheme`.


### PR DESCRIPTION
This PR adds documentation for the `workspace` flag.

This text was introduced in PR #81 which was not merged, in favor of #80. This PR reintroduces the `README.md` update to keep the documentation in line with the implementation. 

Resolves #91 