### PR TITLE
Add optional arch to destination as input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ inputs:
     description: |
       Either `arm64` `x86_64 `i386`
       Leave unset and `xcodebuild` decides itself.
+    required: false
   action:
     description: |
       * The most common actions are `test`, `build`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ async function main() {
   const workspace = core.getInput('workspace')
 
   core.info(`» Selected Xcode ${selected}`)
+  core.info(`» Selected Arch ${arch}`)
 
   const reason: string | false = shouldGenerateXcodeproj()
   if (reason) {


### PR DESCRIPTION
Add option arch to input
'arm64' | 'x86_64' | 'i386'

arch is required (for example) when building on mac M-series with unsupported arm project dependancies 

```
xcodebuild \
  -workspace iosApp.xcworkspace \
  -sdk iphonesimulator \
  -destination 'platform=iOS Simulator,arch=x86_64' \
  build
```