### PR TITLE
Fix wrong `for` loop in `createProvisioningProfiles`

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -499,11 +499,11 @@ export async function createProvisioningProfiles(
 ) {
   core.info('Creating provisioning profiles')
 
-  for (const profile in mobileProfiles) {
+  for (const profile of mobileProfiles) {
     await createProvisioningProfile(profile, '.mobileprovision')
   }
 
-  for (const profile in profiles) {
+  for (const profile of profiles) {
     await createProvisioningProfile(profile, '.provisionprofile')
   }
 }


### PR DESCRIPTION
`for in` is used to iterate objects, not arrays. It ended up iterating over the indices of the array instead of the values.

Anybody actually used this action for setting up provisioning profiles?